### PR TITLE
Update for Elm 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.3",
+    "version": "2.0.0",
     "summary": "A non-empty list data structure.",
     "repository": "https://github.com/hrldcpr/elm-cons.git",
     "license": "BSD3",

--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Cons"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Cons.elm
+++ b/src/Cons.elm
@@ -13,10 +13,10 @@ module Cons
         , foldr1
         , scanl1
         , fromList
-        , cons_
-        , uncons_
-        , tail_
-        , toList_
+        , consWithMaybe
+        , unconsWithMaybe
+        , maybeTail
+        , toMaybeList
         , forList
         , reverse
         , append
@@ -100,11 +100,11 @@ This is useful for recursion on Cons. For example, to recursively find the maxim
 
     maximum : Cons comparable -> comparable
     maximum c =
-      case uncons' c of
+      case unconsWithMaybe c of
         (first, Nothing) -> first
         (first, Just rest) -> max first <| maximum rest
 
-@docs fromList, cons', uncons', tail', toList', forList
+@docs fromList, consWithMaybe, unconsWithMaybe, maybeTail, toMaybeList, forList
 
 
 # Preserving Non-Emptiness
@@ -251,7 +251,7 @@ foldl1 f (Cons head tail) =
 -}
 foldr1 : (a -> a -> a) -> Cons a -> a
 foldr1 f c =
-    case uncons_ c of
+    case unconsWithMaybe c of
         ( head, Nothing ) ->
             head
 
@@ -291,52 +291,52 @@ fromList l =
 
 {-| A cons with the given head and tail.
 
-    c = cons' "a" Nothing
+    c = consWithMaybe "a" Nothing
     toList c == ["a"]
 
-    d = cons' 1 <| Just <| cons' 2 <| Just <| cons' 3 Nothing
+    d = consWithMaybe 1 <| Just <| consWithMaybe 2 <| Just <| consWithMaybe 3 Nothing
     toList d = [1, 2, 3]
 -}
-cons_ : a -> Maybe (Cons a) -> Cons a
-cons_ head tail =
-    cons head <| toList_ tail
+consWithMaybe : a -> Maybe (Cons a) -> Cons a
+consWithMaybe head tail =
+    cons head <| toMaybeList tail
 
 
 {-| The head and tail of the cons.
 
-    c = cons' "a" Nothing
-    uncons' c == ("a", Nothing)
+    c = consWithMaybe "a" Nothing
+    unconsWithMaybe c == ("a", Nothing)
 
-    d = cons' 1 <| Just <| cons' 2 <| Just <| cons' 3 Nothing
-    uncons' d == (1, Just <| cons' 2 <| Just <| cons' 3 Nothing)
+    d = consWithMaybe 1 <| Just <| consWithMaybe 2 <| Just <| consWithMaybe 3 Nothing
+    unconsWithMaybe d == (1, Just <| consWithMaybe 2 <| Just <| consWithMaybe 3 Nothing)
 
     maximum : Cons comparable -> comparable
     maximum c =
-      case uncons' c of
+      case unconsWithMaybe c of
         (first, Nothing) -> first
         (first, Just rest) -> max first <| maximum rest
 -}
-uncons_ : Cons a -> ( a, Maybe (Cons a) )
-uncons_ (Cons head tail) =
+unconsWithMaybe : Cons a -> ( a, Maybe (Cons a) )
+unconsWithMaybe (Cons head tail) =
     ( head, fromList tail )
 
 
 {-| The tail of the cons.
 
-    c = cons' "a" Nothing
-    tail' c == Nothing
+    c = consWithMaybe "a" Nothing
+    maybeTail c == Nothing
 
-    d = cons' 1 <| Just <| cons' 2 <| Just <| cons' 3 Nothing
-    tail' d == Just <| cons' 2 <| Just <| cons' 3 Nothing
+    d = consWithMaybe 1 <| Just <| consWithMaybe 2 <| Just <| consWithMaybe 3 Nothing
+    maybeTail d == Just <| consWithMaybe 2 <| Just <| consWithMaybe 3 Nothing
 
     length : Cons a -> Int
     length c =
-      case tail' c of
+      case maybeTail c of
         Nothing -> 1
         Just rest -> 1 + length rest
 -}
-tail_ : Cons a -> Maybe (Cons a)
-tail_ =
+maybeTail : Cons a -> Maybe (Cons a)
+maybeTail =
     tail >> fromList
 
 
@@ -346,14 +346,14 @@ This is the inverse of fromList.
 
     c = fromList []
     c == Nothing
-    toList' c == []
+    toMaybeList c == []
 
     c = fromList [1, 2, 3]
     c == Just <| cons 1 [2, 3]
-    toList' c == [1, 2, 3]
+    toMaybeList c == [1, 2, 3]
 -}
-toList_ : Maybe (Cons a) -> List a
-toList_ =
+toMaybeList : Maybe (Cons a) -> List a
+toMaybeList =
     Maybe.map toList >> Maybe.withDefault []
 
 
@@ -543,7 +543,7 @@ indexedMap : (Int -> a -> b) -> Cons a -> Cons b
 indexedMap f c =
     let
         go i c =
-            cons_ (f i <| head c) <| Maybe.map (go (i + 1)) <| tail_ c
+            consWithMaybe (f i <| head c) <| Maybe.map (go (i + 1)) <| maybeTail c
     in
         go 0 c
 

--- a/src/Cons.elm
+++ b/src/Cons.elm
@@ -1,11 +1,57 @@
-module Cons exposing
-  ( Cons, cons, uncons, singleton, toList
-  , head, tail, minimum, maximum
-  , foldl1, foldr1, scanl1
-  , fromList, cons', uncons', tail', toList', forList
-  , reverse, append, appendList, appendToList, concat, intersperse, unzip, map, map2, map3, map4, map5, concatMap, indexedMap, scanl, scanlList, sort, sortBy, sortWith
-  , isEmpty, length, member, filter, take, drop, partition, filterMap, foldl, foldr, sum, product, all, any
-  )
+module Cons
+    exposing
+        ( Cons
+        , cons
+        , uncons
+        , singleton
+        , toList
+        , head
+        , tail
+        , minimum
+        , maximum
+        , foldl1
+        , foldr1
+        , scanl1
+        , fromList
+        , cons_
+        , uncons_
+        , tail_
+        , toList_
+        , forList
+        , reverse
+        , append
+        , appendList
+        , appendToList
+        , concat
+        , intersperse
+        , unzip
+        , map
+        , map2
+        , map3
+        , map4
+        , map5
+        , concatMap
+        , indexedMap
+        , scanl
+        , scanlList
+        , sort
+        , sortBy
+        , sortWith
+        , isEmpty
+        , length
+        , member
+        , filter
+        , take
+        , drop
+        , partition
+        , filterMap
+        , foldl
+        , foldr
+        , sum
+        , product
+        , all
+        , any
+        )
 
 {-| This library provides a type for non-empty lists, called `Cons`.
 
@@ -79,16 +125,18 @@ The following are just convenience functions which convert the cons to a list an
 @docs isEmpty, length, member, filter, take, drop, partition, filterMap, foldl, foldr, sum, product, all, any
 -}
 
-
 import List
 
 
 {-| A non-empty list of elements of type `a`.
 -}
-type Cons a = Cons a (List a)
+type Cons a
+    = Cons a (List a)
+
 
 
 -- Basics
+
 
 {-| A cons with the given head and tail. Equivalent to ::
 
@@ -98,15 +146,19 @@ type Cons a = Cons a (List a)
 
 -}
 cons : a -> List a -> Cons a
-cons = Cons
+cons =
+    Cons
+
 
 {-| The head and tail of the cons.
 
     c = cons 1 [2, 3]
     uncons c == (1, [2, 3])
 -}
-uncons : Cons a -> (a, List a)
-uncons (Cons head tail) = (head, tail)
+uncons : Cons a -> ( a, List a )
+uncons (Cons head tail) =
+    ( head, tail )
+
 
 {-| A cons containing only the given element.
 
@@ -114,7 +166,9 @@ uncons (Cons head tail) = (head, tail)
     toList c == ["a"]
 -}
 singleton : a -> Cons a
-singleton x = cons x []
+singleton x =
+    cons x []
+
 
 {-| Convert the cons to the equivalent list.
 
@@ -122,10 +176,13 @@ singleton x = cons x []
     toList c == [1, 2, 3]
 -}
 toList : Cons a -> List a
-toList (Cons head tail) = head::tail
+toList (Cons head tail) =
+    head :: tail
+
 
 
 -- Avoiding Maybe
+
 
 {-| The first element of the cons.
 
@@ -133,7 +190,9 @@ toList (Cons head tail) = head::tail
     head c == 1
 -}
 head : Cons a -> a
-head (Cons head _) = head
+head (Cons head _) =
+    head
+
 
 {-| The list of all elements after the first element of the cons.
 
@@ -141,7 +200,9 @@ head (Cons head _) = head
     tail c == [2, 3]
 -}
 tail : Cons a -> List a
-tail (Cons _ tail) = tail
+tail (Cons _ tail) =
+    tail
+
 
 {-| The smallest element of the cons.
 
@@ -151,7 +212,9 @@ tail (Cons _ tail) = tail
     minimum == foldl1 min
 -}
 minimum : Cons comparable -> comparable
-minimum = foldl1 min
+minimum =
+    foldl1 min
+
 
 {-| The largest element of the cons.
 
@@ -161,10 +224,13 @@ minimum = foldl1 min
     maximum == foldl1 max
 -}
 maximum : Cons comparable -> comparable
-maximum = foldl1 max
+maximum =
+    foldl1 max
+
 
 
 -- Convenient Folding
+
 
 {-| Reduce the cons from the left.
 
@@ -173,7 +239,9 @@ maximum = foldl1 max
     foldl1 step c == "abc"
 -}
 foldl1 : (a -> a -> a) -> Cons a -> a
-foldl1 f (Cons head tail) = List.foldl f head tail
+foldl1 f (Cons head tail) =
+    List.foldl f head tail
+
 
 {-| Reduce the cons from the right.
 
@@ -183,9 +251,13 @@ foldl1 f (Cons head tail) = List.foldl f head tail
 -}
 foldr1 : (a -> a -> a) -> Cons a -> a
 foldr1 f c =
-  case uncons' c of
-    (head, Nothing) -> head
-    (head, Just tail) -> f head <| foldr1 f tail
+    case uncons_ c of
+        ( head, Nothing ) ->
+            head
+
+        ( head, Just tail ) ->
+            f head <| foldr1 f tail
+
 
 {-| Reduce the cons from the left, producing a cons of all intermediate results.
 
@@ -194,10 +266,13 @@ foldr1 f c =
     scanl1 step c == cons "a" ["ab", "abc"]
 -}
 scanl1 : (a -> a -> a) -> Cons a -> Cons a
-scanl1 f (Cons head tail) = scanlList f head tail
+scanl1 f (Cons head tail) =
+    scanlList f head tail
+
 
 
 -- List May Be Cons
+
 
 {-| Convert the list to the equivalent cons, or Nothing for the empty list.
 
@@ -206,9 +281,13 @@ scanl1 f (Cons head tail) = scanlList f head tail
 -}
 fromList : List a -> Maybe (Cons a)
 fromList l =
-  case l of
-    [] -> Nothing
-    head::tail -> Just <| cons head tail
+    case l of
+        [] ->
+            Nothing
+
+        head :: tail ->
+            Just <| cons head tail
+
 
 {-| A cons with the given head and tail.
 
@@ -218,8 +297,10 @@ fromList l =
     d = cons' 1 <| Just <| cons' 2 <| Just <| cons' 3 Nothing
     toList d = [1, 2, 3]
 -}
-cons' : a -> Maybe (Cons a) -> Cons a
-cons' head tail = cons head <| toList' tail
+cons_ : a -> Maybe (Cons a) -> Cons a
+cons_ head tail =
+    cons head <| toList_ tail
+
 
 {-| The head and tail of the cons.
 
@@ -235,8 +316,10 @@ cons' head tail = cons head <| toList' tail
         (first, Nothing) -> first
         (first, Just rest) -> max first <| maximum rest
 -}
-uncons' : Cons a -> (a, Maybe (Cons a))
-uncons' (Cons head tail) = (head, fromList tail)
+uncons_ : Cons a -> ( a, Maybe (Cons a) )
+uncons_ (Cons head tail) =
+    ( head, fromList tail )
+
 
 {-| The tail of the cons.
 
@@ -252,8 +335,10 @@ uncons' (Cons head tail) = (head, fromList tail)
         Nothing -> 1
         Just rest -> 1 + length rest
 -}
-tail' : Cons a -> Maybe (Cons a)
-tail' = tail >> fromList
+tail_ : Cons a -> Maybe (Cons a)
+tail_ =
+    tail >> fromList
+
 
 {-| Convert the cons to the equivalent list, or the empty list for Nothing.
 
@@ -267,8 +352,10 @@ This is the inverse of fromList.
     c == Just <| cons 1 [2, 3]
     toList' c == [1, 2, 3]
 -}
-toList' : Maybe (Cons a) -> List a
-toList' = Maybe.map toList >> Maybe.withDefault []
+toList_ : Maybe (Cons a) -> List a
+toList_ =
+    Maybe.map toList >> Maybe.withDefault []
+
 
 {-| Convert a function that operates on Cons to a function that operates on List, where the empty list results in Nothing.
 
@@ -282,10 +369,13 @@ toList' = Maybe.map toList >> Maybe.withDefault []
     listMaximum [1, 2, 3] == Just 3
 -}
 forList : (Cons a -> b) -> List a -> Maybe b
-forList f = fromList >> Maybe.map f
+forList f =
+    fromList >> Maybe.map f
+
 
 
 -- Preserving Non-Emptiness
+
 
 {-| Reverse the cons.
 
@@ -293,7 +383,9 @@ forList f = fromList >> Maybe.map f
     reverse c == cons 3 [2, 1]
 -}
 reverse : Cons a -> Cons a
-reverse (Cons head tail) = appendToList (List.reverse tail) <| singleton head
+reverse (Cons head tail) =
+    appendToList (List.reverse tail) <| singleton head
+
 
 {-| Append the second cons to the first.
 
@@ -303,10 +395,12 @@ reverse (Cons head tail) = appendToList (List.reverse tail) <| singleton head
 -}
 append : Cons a -> Cons a -> Cons a
 append c d =
-  let
-    step x xs = cons x <| toList xs
-  in
-    foldr step d c
+    let
+        step x xs =
+            cons x <| toList xs
+    in
+        foldr step d c
+
 
 {-| Append a list to a cons.
 
@@ -316,9 +410,13 @@ append c d =
 -}
 appendList : Cons a -> List a -> Cons a
 appendList c l =
-  case fromList l of
-    Nothing -> c
-    Just d -> append c d
+    case fromList l of
+        Nothing ->
+            c
+
+        Just d ->
+            append c d
+
 
 {-| Append a cons to a list.
 
@@ -328,9 +426,13 @@ appendList c l =
 -}
 appendToList : List a -> Cons a -> Cons a
 appendToList l d =
-  case fromList l of
-    Nothing -> d
-    Just c -> append c d
+    case fromList l of
+        Nothing ->
+            d
+
+        Just c ->
+            append c d
+
 
 {-| Concatenate a non-empty list of non-empty lists.
 
@@ -343,7 +445,9 @@ appendToList l d =
     concat == foldr1 append
 -}
 concat : Cons (Cons a) -> Cons a
-concat = foldr1 append
+concat =
+    foldr1 append
+
 
 {-| Intersperse the value between each element of the cons.
 
@@ -352,21 +456,27 @@ concat = foldr1 append
 -}
 intersperse : a -> Cons a -> Cons a
 intersperse x c =
-  case uncons c of
-    (head, []) -> c
-    (head, tail) -> cons head <| x :: List.intersperse x tail
+    case uncons c of
+        ( head, [] ) ->
+            c
+
+        ( head, tail ) ->
+            cons head <| x :: List.intersperse x tail
+
 
 {-| A tuple of each cons, corresponding to a cons of tuples.
 
     c = cons (1, "a") [(2, "b"), (3, "c")]
     unzip c == (cons 1 [2, 3], cons "a" ["b", "c"])
 -}
-unzip : Cons (a, b) -> (Cons a, Cons b)
-unzip (Cons (x, y) tail) =
-  let
-    (xs, ys) = List.unzip tail
-  in
-    (cons x xs, cons y ys)
+unzip : Cons ( a, b ) -> ( Cons a, Cons b )
+unzip (Cons ( x, y ) tail) =
+    let
+        ( xs, ys ) =
+            List.unzip tail
+    in
+        ( cons x xs, cons y ys )
+
 
 {-| Apply a function to each element of the cons.
 
@@ -374,7 +484,9 @@ unzip (Cons (x, y) tail) =
     map sqrt c == cons 1 [2, 3]
 -}
 map : (a -> b) -> Cons a -> Cons b
-map f (Cons head tail) = cons (f head) <| List.map f tail
+map f (Cons head tail) =
+    cons (f head) <| List.map f tail
+
 
 {-| Apply a function to each pair of elements, limited by the shortest cons.
 
@@ -385,19 +497,27 @@ map f (Cons head tail) = cons (f head) <| List.map f tail
     zip c d = cons (1, "a") [(2, "b"), (3, "c")]
 -}
 map2 : (a -> b -> c) -> Cons a -> Cons b -> Cons c
-map2 f (Cons x xs) (Cons y ys) = cons (f x y) <| List.map2 f xs ys
+map2 f (Cons x xs) (Cons y ys) =
+    cons (f x y) <| List.map2 f xs ys
 
-{-|-}
+
+{-| -}
 map3 : (a -> b -> c -> d) -> Cons a -> Cons b -> Cons c -> Cons d
-map3 f (Cons x xs) (Cons y ys) (Cons z zs) = cons (f x y z) <| List.map3 f xs ys zs
+map3 f (Cons x xs) (Cons y ys) (Cons z zs) =
+    cons (f x y z) <| List.map3 f xs ys zs
 
-{-|-}
+
+{-| -}
 map4 : (a -> b -> c -> d -> e) -> Cons a -> Cons b -> Cons c -> Cons d -> Cons e
-map4 f (Cons v vs) (Cons w ws) (Cons x xs) (Cons y ys) = cons (f v w x y) <| List.map4 f vs ws xs ys
+map4 f (Cons v vs) (Cons w ws) (Cons x xs) (Cons y ys) =
+    cons (f v w x y) <| List.map4 f vs ws xs ys
 
-{-|-}
+
+{-| -}
 map5 : (a -> b -> c -> d -> e -> f) -> Cons a -> Cons b -> Cons c -> Cons d -> Cons e -> Cons f
-map5 f (Cons v vs) (Cons w ws) (Cons x xs) (Cons y ys) (Cons z zs) = cons (f v w x y z) <| List.map5 f vs ws xs ys zs
+map5 f (Cons v vs) (Cons w ws) (Cons x xs) (Cons y ys) (Cons z zs) =
+    cons (f v w x y z) <| List.map5 f vs ws xs ys zs
+
 
 {-| Also known as "flat map", map each element of the cons to a cons, and then concatenate them together.
 
@@ -410,7 +530,9 @@ map5 f (Cons v vs) (Cons w ws) (Cons x xs) (Cons y ys) (Cons z zs) = cons (f v w
     concatMap f == concat << map f
 -}
 concatMap : (a -> Cons b) -> Cons a -> Cons b
-concatMap f = concat << map f
+concatMap f =
+    concat << map f
+
 
 {-| Apply a function to each element of the cons, as well as the index.
 
@@ -419,10 +541,12 @@ concatMap f = concat << map f
 -}
 indexedMap : (Int -> a -> b) -> Cons a -> Cons b
 indexedMap f c =
-  let
-    go i c = cons' (f i <| head c) <| Maybe.map (go (i + 1)) <| tail' c
-  in
-    go 0 c
+    let
+        go i c =
+            cons_ (f i <| head c) <| Maybe.map (go (i + 1)) <| tail_ c
+    in
+        go 0 c
+
 
 {-| Reduce the cons from the left, producing a cons of all intermediate results.
 
@@ -431,7 +555,9 @@ indexedMap f c =
     scanl step "" c == cons "" ["a", "ab", "abc"]
 -}
 scanl : (a -> b -> b) -> b -> Cons a -> Cons b
-scanl f x c = scanlList f x <| toList c
+scanl f x c =
+    scanlList f x <| toList c
+
 
 {-| Reduce the list from the left, producing a cons of all intermediate results, since even for the empty list there is one intermediate result.
 
@@ -443,9 +569,14 @@ Equivalent to List.scanl, but with a more specific return type.
 -}
 scanlList : (a -> b -> b) -> b -> List a -> Cons b
 scanlList f x l =
-  cons x <| case l of
-              [] -> []
-              head::tail -> List.scanl f (f head x) tail
+    cons x <|
+        case l of
+            [] ->
+                []
+
+            head :: tail ->
+                List.scanl f (f head x) tail
+
 
 {-| Sort the cons in ascending order.
 
@@ -453,7 +584,9 @@ scanlList f x l =
     sort c == cons 1 [2, 3]
 -}
 sort : Cons comparable -> Cons comparable
-sort = sortWith compare
+sort =
+    sortWith compare
+
 
 {-| Sort the cons in ascending order, by applying the given function to each value.
 
@@ -465,7 +598,9 @@ sort = sortWith compare
     sortBy .age c == cons bob [alice, charlie]
 -}
 sortBy : (a -> comparable) -> Cons a -> Cons a
-sortBy f = sortWith (\x y -> compare (f x) (f y))
+sortBy f =
+    sortWith (\x y -> compare (f x) (f y))
+
 
 {-| Sort the cons in ascending order, based on the given comparison function.
 
@@ -482,29 +617,39 @@ sortBy f = sortWith (\x y -> compare (f x) (f y))
     sortWith compare == sort
 -}
 sortWith : (a -> a -> Order) -> Cons a -> Cons a
-sortWith f c = insortWith f (head c) <| List.sortWith f <| tail c
+sortWith f c =
+    insortWith f (head c) <| List.sortWith f <| tail c
+
+
 
 -- insert a value into a sorted list
+
+
 insortWith : (a -> a -> Order) -> a -> List a -> Cons a
 insortWith f x l =
-  case l of
-    [] ->
-      singleton x
-    head::tail ->
-      if f x head == GT then
-        cons head <| toList <| insortWith f x tail
-      else
-        cons x l
+    case l of
+        [] ->
+            singleton x
+
+        head :: tail ->
+            if f x head == GT then
+                cons head <| toList <| insortWith f x tail
+            else
+                cons x l
+
 
 
 -- List Functions
+
 
 {-| Always false for a cons, only here to make porting List code easier.
 
     isEmpty == always False
 -}
 isEmpty : Cons a -> Bool
-isEmpty = toList >> List.isEmpty
+isEmpty =
+    toList >> List.isEmpty
+
 
 {-| The number of elements in the cons.
 
@@ -512,7 +657,9 @@ isEmpty = toList >> List.isEmpty
     length c == 3
 -}
 length : Cons a -> Int
-length = toList >> List.length
+length =
+    toList >> List.length
+
 
 {-| True if and only if the given element is in the given cons.
 
@@ -521,7 +668,9 @@ length = toList >> List.length
     member 2 c == True
 -}
 member : a -> Cons a -> Bool
-member x = toList >> List.member x
+member x =
+    toList >> List.member x
+
 
 {-| The list of elements from the cons which satisfy the given predicate. This can't generally be a cons itself, because it might be empty.
 
@@ -530,7 +679,9 @@ member x = toList >> List.member x
     filter (\x -> x > 1) c == [2, 3]
 -}
 filter : (a -> Bool) -> Cons a -> List a
-filter f = toList >> List.filter f
+filter f =
+    toList >> List.filter f
+
 
 {-| The first *n* elements of the cons, up to the length of the cons. This can't generally be a cons itself, since *n* might not be positive.
 
@@ -540,7 +691,9 @@ filter f = toList >> List.filter f
     take -10 c == []
 -}
 take : Int -> Cons a -> List a
-take n = toList >> List.take n
+take n =
+    toList >> List.take n
+
 
 {-| The cons without its first *n* elements. This can't generally be a cons itself, because it might be empty.
 
@@ -550,15 +703,19 @@ take n = toList >> List.take n
     drop -10 c == toList c
 -}
 drop : Int -> Cons a -> List a
-drop n = toList >> List.drop n
+drop n =
+    toList >> List.drop n
+
 
 {-| Partition the cons into two lists, the first containing the elements which satisfy the given predicate, the second containing the elements which don't. These can't generally be a cons themselves, since one might be empty.
 
     c = cons 1 [2, 3]
     partition (\x -> x > 1) c == ([2, 3], [1])
 -}
-partition : (a -> Bool) -> Cons a -> (List a, List a)
-partition f = toList >> List.partition f
+partition : (a -> Bool) -> Cons a -> ( List a, List a )
+partition f =
+    toList >> List.partition f
+
 
 {-| Map the given Maybe function over the cons, discarding every Nothing. This can't generally be a cons itself, because it might be empty.
 
@@ -568,7 +725,9 @@ partition f = toList >> List.partition f
     filterMap String.toInt c == [1, 2]
 -}
 filterMap : (a -> Maybe b) -> Cons a -> List b
-filterMap f = toList >> List.filterMap f
+filterMap f =
+    toList >> List.filterMap f
+
 
 {-| Reduce the cons from the right, starting with the given value. To start with the last value in the cons, use [foldr1](#foldr1).
 
@@ -577,7 +736,9 @@ filterMap f = toList >> List.filterMap f
     foldr1 step "x" c == "xcba"
 -}
 foldr : (a -> b -> b) -> b -> Cons a -> b
-foldr f x = toList >> List.foldr f x
+foldr f x =
+    toList >> List.foldr f x
+
 
 {-| Reduce the cons from the left, starting with the given value. To start with the first value in the cons, use [foldl1](#foldl1).
 
@@ -586,7 +747,9 @@ foldr f x = toList >> List.foldr f x
     foldl1 step "x" c == "xabc"
 -}
 foldl : (a -> b -> b) -> b -> Cons a -> b
-foldl f x = toList >> List.foldl f x
+foldl f x =
+    toList >> List.foldl f x
+
 
 {-| The sum of the elements of the cons.
 
@@ -594,7 +757,9 @@ foldl f x = toList >> List.foldl f x
     sum c == 9
 -}
 sum : Cons number -> number
-sum = toList >> List.sum
+sum =
+    toList >> List.sum
+
 
 {-| The product of the elements of the cons.
 
@@ -602,7 +767,9 @@ sum = toList >> List.sum
     product c == 24
 -}
 product : Cons number -> number
-product = toList >> List.product
+product =
+    toList >> List.product
+
 
 {-| True if and only if all elements of the cons satisfy the given predicate.
 
@@ -611,7 +778,9 @@ product = toList >> List.product
     all (\x -> x > 0) == True
 -}
 all : (a -> Bool) -> Cons a -> Bool
-all f = toList >> List.all f
+all f =
+    toList >> List.all f
+
 
 {-| True if and only if any elements of the cons satisfy the given predicate.
 
@@ -620,4 +789,5 @@ all f = toList >> List.all f
     any (\x -> x > 2) == True
 -}
 any : (a -> Bool) -> Cons a -> Bool
-any f = toList >> List.any f
+any f =
+    toList >> List.any f

--- a/src/Cons.elm
+++ b/src/Cons.elm
@@ -16,7 +16,7 @@ module Cons
         , consWithMaybe
         , unconsWithMaybe
         , maybeTail
-        , toMaybeList
+        , maybeToList
         , forList
         , reverse
         , append
@@ -104,7 +104,7 @@ This is useful for recursion on Cons. For example, to recursively find the maxim
         (first, Nothing) -> first
         (first, Just rest) -> max first <| maximum rest
 
-@docs fromList, consWithMaybe, unconsWithMaybe, maybeTail, toMaybeList, forList
+@docs fromList, consWithMaybe, unconsWithMaybe, maybeTail, maybeToList, forList
 
 
 # Preserving Non-Emptiness
@@ -299,7 +299,7 @@ fromList l =
 -}
 consWithMaybe : a -> Maybe (Cons a) -> Cons a
 consWithMaybe head tail =
-    cons head <| toMaybeList tail
+    cons head <| maybeToList tail
 
 
 {-| The head and tail of the cons.
@@ -346,14 +346,14 @@ This is the inverse of fromList.
 
     c = fromList []
     c == Nothing
-    toMaybeList c == []
+    maybeToList c == []
 
     c = fromList [1, 2, 3]
     c == Just <| cons 1 [2, 3]
-    toMaybeList c == [1, 2, 3]
+    maybeToList c == [1, 2, 3]
 -}
-toMaybeList : Maybe (Cons a) -> List a
-toMaybeList =
+maybeToList : Maybe (Cons a) -> List a
+maybeToList =
     Maybe.map toList >> Maybe.withDefault []
 
 

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
+
+
+main : TestProgram
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -3,310 +3,131 @@ module Tests exposing (..)
 import Check exposing (..)
 import Check.Producer exposing (..)
 import Check.Test
-import ElmTest
-
+import Legacy.ElmTest as ElmTest
 import Cons exposing (..)
 import List
 
 
 main =
-  ElmTest.runSuite all
+    ElmTest.runSuite all
+
 
 all =
-  quickCheck checkSuite |> Check.Test.evidenceToTest
+    quickCheck checkSuite |> Check.Test.evidenceToTest
+
 
 checkSuite =
-  suite "elm-check tests"
-  [
-  -- Basics
+    suite "elm-check tests"
+        [ -- Basics
+          for (is (that (claim "cons agrees with ::") (uncurry Cons.cons >> toList)) (uncurry (::))) (tuple ( int, list int ))
+        , for (is (that (claim "cons is inverse of uncons") (uncurry Cons.cons << uncons)) identity) (cons int)
+        , for (is (that (claim "uncons is inverse of cons") (uncons << uncurry Cons.cons)) identity) (tuple ( int, list int ))
+        , for (is (that (claim "singleton cons agrees with singleton list") (singleton >> toList)) (\x -> [ x ])) int
+        , for (is (that (claim "toList agrees with toList'") toList) (toList_ << Just)) (cons int)
+          -- Avoiding Maybe
+        , for (is (that (claim "head agrees with List.head") (head >> Just)) (List.head << toList)) (cons int)
+        , for (is (that (claim "tail agrees with List.tail") (tail >> Just)) (List.tail << toList)) (cons int)
+        , for (is (that (claim "minimum agrees with List.minimum") (minimum >> Just)) (List.minimum << toList)) (cons int)
+        , for (is (that (claim "maximum agrees with List.maximum") (maximum >> Just)) (List.maximum << toList)) (cons int)
+          -- Convenient Folding
+        , for (is (that (claim "foldl1 agrees with List.foldl") (foldl1 (++))) (\c -> List.foldl (++) (head c) <| tail c)) (cons string)
+        , for (is (that (claim "foldr1 is the reverse of foldl1") (foldr1 (++))) (foldl1 (++) << reverse)) (cons string)
+        , for (is (that (claim "scanl1 agrees with scanlList") (scanl1 (++))) (\c -> scanlList (++) (head c) <| tail c)) (cons string)
+          -- List May Be Cons
+        , for (is (that (claim "fromList is inverse of toList'") (fromList << toList_)) identity) (maybe (cons int))
+        , for (is (that (claim "cons' is inverse of uncons'") (uncurry cons_ << uncons_)) identity) (cons int)
+        , for (is (that (claim "uncons' is inverse of cons'") (uncons_ << uncurry cons_)) identity) (tuple ( int, maybe (cons int) ))
+        , for (is (that (claim "tail' agrees with tail") tail_) (tail >> fromList)) (cons int)
+        , for (is (that (claim "toList' is inverse of fromList") (toList_ << fromList)) identity) (list int)
+        , for (is (that (claim "forList turns head, tail, minimum, and maximum into their List equivalents") (\l -> ( forList head l, forList tail l, forList minimum l, forList maximum l ))) (\l -> ( List.head l, List.tail l, List.minimum l, List.maximum l ))) (list int)
+          -- Preserving Non-Emptiness
+        , for (is (that (claim "reverse agrees with List.reverse") (reverse >> toList)) (List.reverse << toList)) (cons int)
+        , for (is (that (claim "append agrees with List.append") (uncurry append >> toList)) (\( c, d ) -> List.append (toList c) <| toList d)) (tuple ( cons int, cons int ))
+        , for (is (that (claim "appendList agrees with List.append") (uncurry appendList >> toList)) (\( c, l ) -> List.append (toList c) l)) (tuple ( cons int, list int ))
+        , for (is (that (claim "appendToList agrees with List.append") (uncurry appendToList >> toList)) (\( l, d ) -> List.append l <| toList d)) (tuple ( list int, cons int ))
+        , for (is (that (claim "concat agrees with List.concat") (concat >> toList)) (List.concat << toList << Cons.map toList)) (cons (cons int))
+        , for (is (that (claim "intersperse agrees with List.intersperse") (uncurry intersperse >> toList)) (\( x, c ) -> List.intersperse x <| toList c)) (tuple ( int, cons int ))
+        , for
+            (is
+                (that (claim "unzip agrees with List.unzip")
+                    (\cd ->
+                        let
+                            ( c, d ) =
+                                unzip cd
+                        in
+                            ( toList c, toList d )
+                    )
+                )
+                (List.unzip << toList)
+            )
+            (cons (tuple ( int, string )))
+        , for (is (that (claim "map agrees with List.map") (Cons.map toString >> toList)) (List.map toString << toList)) (cons int)
+        , for (is (that (claim "map2 agrees with List.map2") (\( c, d ) -> Cons.map2 toString2 c d |> toList)) (\( c, d ) -> List.map2 toString2 (toList c) (toList d))) (tuple ( cons int, cons string ))
+        , for (is (that (claim "map3 agrees with List.map3") (\( a, b, c ) -> Cons.map3 toString3 a b c |> toList)) (\( a, b, c ) -> List.map3 toString3 (toList a) (toList b) (toList c))) (tuple3 ( cons int, cons string, cons float ))
+        , for (is (that (claim "map4 agrees with List.map4") (\( a, b, c, d ) -> Cons.map4 toString4 a b c d |> toList)) (\( a, b, c, d ) -> List.map4 toString4 (toList a) (toList b) (toList c) (toList d))) (tuple4 ( cons int, cons string, cons float, cons bool ))
+        , for (is (that (claim "map5 agrees with List.map5") (\( a, b, c, d, e ) -> Cons.map5 toString5 a b c d e |> toList)) (\( a, b, c, d, e ) -> List.map5 toString5 (toList a) (toList b) (toList c) (toList d) (toList e))) (tuple5 ( cons int, cons string, cons float, cons bool, cons percentage ))
+        , for (is (that (claim "concatMap agrees with List.concatMap") (concatMap reverse >> toList)) (List.concatMap (reverse >> toList) << toList)) (cons (cons int))
+        , for (is (that (claim "indexedMap agrees with List.indexedMap") (indexedMap toString2 >> toList)) (List.indexedMap toString2 << toList)) (cons int)
+        , for (is (that (claim "scanl agrees with scanlList") (\( x, c ) -> scanl (++) x c)) (\( x, c ) -> scanlList (++) x <| toList c)) (tuple ( string, cons string ))
+        , for (is (that (claim "scanlList agrees with List.scanl") (\( x, l ) -> scanlList (++) x l |> toList)) (\( x, l ) -> List.scanl (++) x l)) (tuple ( string, list string ))
+        , for (is (that (claim "sort agrees with List.sort") (sort >> toList)) (List.sort << toList)) (cons int)
+        , for (is (that (claim "sortBy agrees with List.sortBy") (sortBy (\x -> -x) >> toList)) (List.sortBy (\x -> -x) << toList)) (cons int)
+        , for (is (that (claim "sortWith agrees with List.sortWith") (sortWith reverseCompare >> toList)) (List.sortWith reverseCompare << toList)) (cons int)
+          -- List Functions
+        , for (is (that (claim "isEmpty agrees with List.isEmpty") isEmpty) (List.isEmpty << toList)) (cons int)
+        , for (is (that (claim "length agrees with List.length") length) (List.length << toList)) (cons int)
+        , for (is (that (claim "member agrees with List.member") (uncurry member)) (\( x, c ) -> List.member x <| toList c)) (tuple ( int, cons int ))
+        , for (is (that (claim "filter agrees with List.filter") (Cons.filter ((<) 0))) (List.filter ((<) 0) << toList)) (cons int)
+        , for (is (that (claim "take agrees with List.take") (uncurry take)) (\( n, c ) -> List.take n <| toList c)) (tuple ( int, cons string ))
+        , for (is (that (claim "drop agrees with List.drop") (uncurry drop)) (\( n, c ) -> List.drop n <| toList c)) (tuple ( int, cons string ))
+        , for (is (that (claim "partition agrees with List.partition") (partition ((<) 0))) (List.partition ((<) 0) << toList)) (cons int)
+        , for (is (that (claim "filterMap agrees with List.filterMap") (filterMap (sqrt >> maybeNaN))) (List.filterMap (sqrt >> maybeNaN) << toList)) (cons float)
+        , for (is (that (claim "foldl agrees with List.foldl") (\( x, c ) -> foldl (++) x c)) (\( x, c ) -> List.foldl (++) x <| toList c)) (tuple ( string, cons string ))
+        , for (is (that (claim "foldr agrees with List.foldr") (\( x, c ) -> foldr (++) x c)) (\( x, c ) -> List.foldr (++) x <| toList c)) (tuple ( string, cons string ))
+        , for (is (that (claim "isEmpty agrees with List.isEmpty") isEmpty) (List.isEmpty << toList)) (cons int)
+        , for (is (that (claim "isEmpty agrees with List.isEmpty") isEmpty) (List.isEmpty << toList)) (cons int)
+        , for (is (that (claim "isEmpty agrees with List.isEmpty") isEmpty) (List.isEmpty << toList)) (cons int)
+        , for (is (that (claim "isEmpty agrees with List.isEmpty") isEmpty) (List.isEmpty << toList)) (cons int)
+        ]
 
-    claim "cons agrees with ::"
-  `that` (uncurry Cons.cons >> toList)
-  `is` (uncurry (::))
-  `for` tuple (int, list int)
-
-  , claim "cons is inverse of uncons"
-  `that` (uncurry Cons.cons << uncons)
-  `is` identity
-  `for` cons int
-
-  , claim "uncons is inverse of cons"
-  `that` (uncons << uncurry Cons.cons)
-  `is` identity
-  `for` tuple (int, list int)
-
-  , claim "singleton cons agrees with singleton list"
-  `that` (singleton >> toList)
-  `is` (\x -> [x])
-  `for` int
-
-  , claim "toList agrees with toList'"
-  `that` toList
-  `is` (toList' << Just)
-  `for` cons int
-
-
-  -- Avoiding Maybe
-
-  , claim "head agrees with List.head"
-  `that` (head >> Just)
-  `is` (List.head << toList)
-  `for` cons int
-
-  , claim "tail agrees with List.tail"
-  `that` (tail >> Just)
-  `is` (List.tail << toList)
-  `for` cons int
-
-  , claim "minimum agrees with List.minimum"
-  `that` (minimum >> Just)
-  `is` (List.minimum << toList)
-  `for` cons int
-
-  , claim "maximum agrees with List.maximum"
-  `that` (maximum >> Just)
-  `is` (List.maximum << toList)
-  `for` cons int
-
-
-  -- Convenient Folding
-
-  , claim "foldl1 agrees with List.foldl"
-  `that` (foldl1 (++))
-  `is` (\c -> List.foldl (++) (head c) <| tail c)
-  `for` cons string
-
-  , claim "foldr1 is the reverse of foldl1"
-  `that` (foldr1 (++))
-  `is` (foldl1 (++) << reverse)
-  `for` cons string
-
-  , claim "scanl1 agrees with scanlList"
-  `that` (scanl1 (++))
-  `is` (\c -> scanlList (++) (head c) <| tail c)
-  `for` cons string
-
-
-  -- List May Be Cons
-
-  , claim "fromList is inverse of toList'"
-  `that` (fromList << toList')
-  `is` identity
-  `for` maybe (cons int)
-
-  , claim "cons' is inverse of uncons'"
-  `that` (uncurry cons' << uncons')
-  `is` identity
-  `for` cons int
-
-  , claim "uncons' is inverse of cons'"
-  `that` (uncons' << uncurry cons')
-  `is` identity
-  `for` tuple (int, maybe (cons int))
-
-  , claim "tail' agrees with tail"
-  `that` tail'
-  `is` (tail >> fromList)
-  `for` cons int
-
-  , claim "toList' is inverse of fromList"
-  `that` (toList' << fromList)
-  `is` identity
-  `for` list int
-
-  , claim "forList turns head, tail, minimum, and maximum into their List equivalents"
-  `that` (\l -> (forList head l, forList tail l, forList minimum l, forList maximum l))
-  `is` (\l -> (List.head l, List.tail l, List.minimum l, List.maximum l))
-  `for` list int
-
-
-  -- Preserving Non-Emptiness
-
-  , claim "reverse agrees with List.reverse"
-  `that` (reverse >> toList)
-  `is` (List.reverse << toList)
-  `for` cons int
-
-  , claim "append agrees with List.append"
-  `that` (uncurry append >> toList)
-  `is` (\(c, d) -> List.append (toList c) <| toList d)
-  `for` tuple (cons int, cons int)
-
-  , claim "appendList agrees with List.append"
-  `that` (uncurry appendList >> toList)
-  `is` (\(c, l) -> List.append (toList c) l)
-  `for` tuple (cons int, list int)
-
-  , claim "appendToList agrees with List.append"
-  `that` (uncurry appendToList >> toList)
-  `is` (\(l, d) -> List.append l <| toList d)
-  `for` tuple (list int, cons int)
-
-  , claim "concat agrees with List.concat"
-  `that` (concat >> toList)
-  `is` (List.concat << toList << Cons.map toList)
-  `for` cons (cons int)
-
-  , claim "intersperse agrees with List.intersperse"
-  `that` (uncurry intersperse >> toList)
-  `is` (\(x, c) -> List.intersperse x <| toList c)
-  `for` tuple (int, cons int)
-
-  , claim "unzip agrees with List.unzip"
-  `that` (\cd -> let (c, d) = unzip cd in (toList c, toList d))
-  `is` (List.unzip << toList)
-  `for` cons (tuple (int, string))
-
-  , claim "map agrees with List.map"
-  `that` (Cons.map toString >> toList)
-  `is` (List.map toString << toList)
-  `for` cons int
-
-  , claim "map2 agrees with List.map2"
-  `that` (\(c, d) -> Cons.map2 toString2 c d |> toList)
-  `is` (\(c, d) -> List.map2 toString2 (toList c) (toList d))
-  `for` tuple (cons int, cons string)
-
-  , claim "map3 agrees with List.map3"
-  `that` (\(a, b, c) -> Cons.map3 toString3 a b c |> toList)
-  `is` (\(a, b, c) -> List.map3 toString3 (toList a) (toList b) (toList c))
-  `for` tuple3 (cons int, cons string, cons float)
-
-  , claim "map4 agrees with List.map4"
-  `that` (\(a, b, c, d) -> Cons.map4 toString4 a b c d |> toList)
-  `is` (\(a, b, c, d) -> List.map4 toString4 (toList a) (toList b) (toList c) (toList d))
-  `for` tuple4 (cons int, cons string, cons float, cons bool)
-
-  , claim "map5 agrees with List.map5"
-  `that` (\(a, b, c, d, e) -> Cons.map5 toString5 a b c d e |> toList)
-  `is` (\(a, b, c, d, e) -> List.map5 toString5 (toList a) (toList b) (toList c) (toList d) (toList e))
-  `for` tuple5 (cons int, cons string, cons float, cons bool, cons percentage)
-
-  , claim "concatMap agrees with List.concatMap"
-  `that` (concatMap reverse >> toList)
-  `is` (List.concatMap (reverse >> toList) << toList)
-  `for` cons (cons int)
-
-  , claim "indexedMap agrees with List.indexedMap"
-  `that` (indexedMap toString2 >> toList)
-  `is` (List.indexedMap toString2 << toList)
-  `for` cons int
-
-  , claim "scanl agrees with scanlList"
-  `that` (\(x, c) -> scanl (++) x c)
-  `is` (\(x, c) -> scanlList (++) x <| toList c)
-  `for` tuple (string, cons string)
-
-  , claim "scanlList agrees with List.scanl"
-  `that` (\(x, l) -> scanlList (++) x l |> toList)
-  `is` (\(x, l) -> List.scanl (++) x l)
-  `for` tuple (string, list string)
-
-  , claim "sort agrees with List.sort"
-  `that` (sort >> toList)
-  `is` (List.sort << toList)
-  `for` cons int
-
-  , claim "sortBy agrees with List.sortBy"
-  `that` (sortBy (\x -> -x) >> toList)
-  `is` (List.sortBy (\x -> -x) << toList)
-  `for` cons int
-
-  , claim "sortWith agrees with List.sortWith"
-  `that` (sortWith reverseCompare >> toList)
-  `is` (List.sortWith reverseCompare << toList)
-  `for` cons int
-
-
-  -- List Functions
-
-  , claim "isEmpty agrees with List.isEmpty"
-  `that` isEmpty
-  `is` (List.isEmpty << toList)
-  `for` cons int
-
-  , claim "length agrees with List.length"
-  `that` length
-  `is` (List.length << toList)
-  `for` cons int
-
-  , claim "member agrees with List.member"
-  `that` (uncurry member)
-  `is` (\(x, c) -> List.member x <| toList c)
-  `for` tuple (int, cons int)
-
-  , claim "filter agrees with List.filter"
-  `that` (Cons.filter ((<) 0))
-  `is` (List.filter ((<) 0) << toList)
-  `for` cons int
-
-  , claim "take agrees with List.take"
-  `that` (uncurry take)
-  `is` (\(n, c) -> List.take n <| toList c)
-  `for` tuple (int, cons string)
-
-  , claim "drop agrees with List.drop"
-  `that` (uncurry drop)
-  `is` (\(n, c) -> List.drop n <| toList c)
-  `for` tuple (int, cons string)
-
-  , claim "partition agrees with List.partition"
-  `that` (partition ((<) 0))
-  `is` (List.partition ((<) 0) << toList)
-  `for` cons int
-
-  , claim "filterMap agrees with List.filterMap"
-  `that` (filterMap (sqrt >> maybeNaN))
-  `is` (List.filterMap (sqrt >> maybeNaN) << toList)
-  `for` cons float
-
-  , claim "foldl agrees with List.foldl"
-  `that` (\(x, c) -> foldl (++) x c)
-  `is` (\(x, c) -> List.foldl (++) x <| toList c)
-  `for` tuple (string, cons string)
-
-  , claim "foldr agrees with List.foldr"
-  `that` (\(x, c) -> foldr (++) x c)
-  `is` (\(x, c) -> List.foldr (++) x <| toList c)
-  `for` tuple (string, cons string)
-
-  , claim "isEmpty agrees with List.isEmpty"
-  `that` isEmpty
-  `is` (List.isEmpty << toList)
-  `for` cons int
-
-  , claim "isEmpty agrees with List.isEmpty"
-  `that` isEmpty
-  `is` (List.isEmpty << toList)
-  `for` cons int
-
-  , claim "isEmpty agrees with List.isEmpty"
-  `that` isEmpty
-  `is` (List.isEmpty << toList)
-  `for` cons int
-
-  , claim "isEmpty agrees with List.isEmpty"
-  `that` isEmpty
-  `is` (List.isEmpty << toList)
-  `for` cons int
-
-  ]
 
 cons : Producer a -> Producer (Cons a)
 cons x =
-  convert (uncurry Cons.cons) uncons <| tuple (x, list x)
+    convert (uncurry Cons.cons) uncons <| tuple ( x, list x )
 
-toString2 x y = toString (x, y)
-toString3 x y z = toString (x, y, z)
-toString4 w x y z = toString (w, x, y, z)
-toString5 v w x y z = toString (v, w, x, y, z)
+
+toString2 x y =
+    toString ( x, y )
+
+
+toString3 x y z =
+    toString ( x, y, z )
+
+
+toString4 w x y z =
+    toString ( w, x, y, z )
+
+
+toString5 v w x y z =
+    toString ( v, w, x, y, z )
+
 
 reverseCompare : comparable -> comparable -> Order
 reverseCompare x y =
-  case compare x y of
-    LT -> GT
-    EQ -> EQ
-    GT -> LT
+    case compare x y of
+        LT ->
+            GT
+
+        EQ ->
+            EQ
+
+        GT ->
+            LT
+
 
 maybeNaN : Float -> Maybe Float
-maybeNaN x = if isNaN x then Nothing else Just x
+maybeNaN x =
+    if isNaN x then
+        Nothing
+    else
+        Just x

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -23,7 +23,7 @@ checkSuite =
         , for (is (that (claim "cons is inverse of uncons") (uncurry Cons.cons << uncons)) identity) (cons int)
         , for (is (that (claim "uncons is inverse of cons") (uncons << uncurry Cons.cons)) identity) (tuple ( int, list int ))
         , for (is (that (claim "singleton cons agrees with singleton list") (singleton >> toList)) (\x -> [ x ])) int
-        , for (is (that (claim "toList agrees with toMaybeList") toList) (toMaybeList << Just)) (cons int)
+        , for (is (that (claim "toList agrees with maybeToList") toList) (maybeToList << Just)) (cons int)
           -- Avoiding Maybe
         , for (is (that (claim "head agrees with List.head") (head >> Just)) (List.head << toList)) (cons int)
         , for (is (that (claim "tail agrees with List.tail") (tail >> Just)) (List.tail << toList)) (cons int)
@@ -34,11 +34,11 @@ checkSuite =
         , for (is (that (claim "foldr1 is the reverse of foldl1") (foldr1 (++))) (foldl1 (++) << reverse)) (cons string)
         , for (is (that (claim "scanl1 agrees with scanlList") (scanl1 (++))) (\c -> scanlList (++) (head c) <| tail c)) (cons string)
           -- List May Be Cons
-        , for (is (that (claim "fromList is inverse of toMaybeList") (fromList << toMaybeList)) identity) (maybe (cons int))
+        , for (is (that (claim "fromList is inverse of maybeToList") (fromList << maybeToList)) identity) (maybe (cons int))
         , for (is (that (claim "consWithMaybe is inverse of unconsWithMaybe") (uncurry consWithMaybe << unconsWithMaybe)) identity) (cons int)
         , for (is (that (claim "unconsWithMaybe is inverse of consWithMaybe") (unconsWithMaybe << uncurry consWithMaybe)) identity) (tuple ( int, maybe (cons int) ))
         , for (is (that (claim "maybeTail agrees with tail") maybeTail) (tail >> fromList)) (cons int)
-        , for (is (that (claim "toMaybeList is inverse of fromList") (toMaybeList << fromList)) identity) (list int)
+        , for (is (that (claim "maybeToList is inverse of fromList") (maybeToList << fromList)) identity) (list int)
         , for (is (that (claim "forList turns head, tail, minimum, and maximum into their List equivalents") (\l -> ( forList head l, forList tail l, forList minimum l, forList maximum l ))) (\l -> ( List.head l, List.tail l, List.minimum l, List.maximum l ))) (list int)
           -- Preserving Non-Emptiness
         , for (is (that (claim "reverse agrees with List.reverse") (reverse >> toList)) (List.reverse << toList)) (cons int)

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -23,7 +23,7 @@ checkSuite =
         , for (is (that (claim "cons is inverse of uncons") (uncurry Cons.cons << uncons)) identity) (cons int)
         , for (is (that (claim "uncons is inverse of cons") (uncons << uncurry Cons.cons)) identity) (tuple ( int, list int ))
         , for (is (that (claim "singleton cons agrees with singleton list") (singleton >> toList)) (\x -> [ x ])) int
-        , for (is (that (claim "toList agrees with toList'") toList) (toList_ << Just)) (cons int)
+        , for (is (that (claim "toList agrees with toMaybeList") toList) (toMaybeList << Just)) (cons int)
           -- Avoiding Maybe
         , for (is (that (claim "head agrees with List.head") (head >> Just)) (List.head << toList)) (cons int)
         , for (is (that (claim "tail agrees with List.tail") (tail >> Just)) (List.tail << toList)) (cons int)
@@ -34,11 +34,11 @@ checkSuite =
         , for (is (that (claim "foldr1 is the reverse of foldl1") (foldr1 (++))) (foldl1 (++) << reverse)) (cons string)
         , for (is (that (claim "scanl1 agrees with scanlList") (scanl1 (++))) (\c -> scanlList (++) (head c) <| tail c)) (cons string)
           -- List May Be Cons
-        , for (is (that (claim "fromList is inverse of toList'") (fromList << toList_)) identity) (maybe (cons int))
-        , for (is (that (claim "cons' is inverse of uncons'") (uncurry cons_ << uncons_)) identity) (cons int)
-        , for (is (that (claim "uncons' is inverse of cons'") (uncons_ << uncurry cons_)) identity) (tuple ( int, maybe (cons int) ))
-        , for (is (that (claim "tail' agrees with tail") tail_) (tail >> fromList)) (cons int)
-        , for (is (that (claim "toList' is inverse of fromList") (toList_ << fromList)) identity) (list int)
+        , for (is (that (claim "fromList is inverse of toMaybeList") (fromList << toMaybeList)) identity) (maybe (cons int))
+        , for (is (that (claim "consWithMaybe is inverse of unconsWithMaybe") (uncurry consWithMaybe << unconsWithMaybe)) identity) (cons int)
+        , for (is (that (claim "unconsWithMaybe is inverse of consWithMaybe") (unconsWithMaybe << uncurry consWithMaybe)) identity) (tuple ( int, maybe (cons int) ))
+        , for (is (that (claim "maybeTail agrees with tail") maybeTail) (tail >> fromList)) (cons int)
+        , for (is (that (claim "toMaybeList is inverse of fromList") (toMaybeList << fromList)) identity) (list int)
         , for (is (that (claim "forList turns head, tail, minimum, and maximum into their List equivalents") (\l -> ( forList head l, forList tail l, forList minimum l, forList maximum l ))) (\l -> ( List.head l, List.tail l, List.minimum l, List.maximum l ))) (list int)
           -- Preserving Non-Emptiness
         , for (is (that (claim "reverse agrees with List.reverse") (reverse >> toList)) (List.reverse << toList)) (cons int)

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,9 +9,11 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-check": "1.0.0 <= v < 2.0.0",
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-community/elm-check": "2.0.1 <= v < 3.0.0",
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "rtfeldman/legacy-elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,2 +1,0 @@
-js=elm-stuff/tests.js
-elm make Tests.elm --output $js && node $js


### PR DESCRIPTION
This is my favourite elm library for non-empty lists by far, so here's a PR for `Cons` to be compatible with 0.18. This would be a major version change. 

The two big changes are:

- Renaming `cons'`, `uncons'`, `tail'` and `toList'` to `consWithMaybe`, `unconsWithMaybe`, `maybeTail` and `toMaybeList`, as primes are no longer permitted in Elm 0.18, and the default replacement of replacing the apostrophe with an underscore seemed confusing.
- Updating the test suite to use `legacy-elm-test` and `node-test-runner`.

Smaller stuff: 
- Support for backticks was also removed in 0.18, so the tests now read very weirdly (even though they still work and pass).
- The automatic migration also ran everything through elm-format. Clearly this style is not @hrldcpr’s preferred one, but I hope it's okay.